### PR TITLE
adjusting the syntax for the Astro edge functions adapter

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,10 +1,12 @@
 import { defineConfig } from 'astro/config';
-import netlify from '@astrojs/netlify/edge-functions';
+import netlify from "@astrojs/netlify/functions";
 import react from "@astrojs/react";
 
 // https://astro.build/config
 export default defineConfig({
   integrations: [react()],
-  adapter: netlify(),
+  adapter: netlify({
+    edgeMiddleware: true
+  }),
   output: 'server'
 });


### PR DESCRIPTION
The Astro Edge Functions adapter has changed it's syntax.  Updating to the syntax suggested in this thread [https://answers.netlify.com/t/astro-edge-function-crashing-build-since-yesterday/104147] fixes some glitches when calling Edge Functions within an Astro app.